### PR TITLE
fixes build issue in Ubuntu 22.04

### DIFF
--- a/src/sample.h
+++ b/src/sample.h
@@ -8,6 +8,7 @@
 #include <boost/serialization/split_member.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <iosfwd>
+#include <limits>
 
 #ifndef BOOST_BYTE_ORDER
 #if BOOST_ENDIAN_BIG_BYTE


### PR DESCRIPTION
# Summary

Fixes build error in Ubuntu 22.04

# Error
```
[ 19%] Building CXX object liblsl/CMakeFiles/lslobj.dir/src/sample.cpp.o
In file included from /home/casmat/dev/hack/plotjuggler-lsl/liblsl/src/sample.cpp:2:
/home/casmat/dev/hack/plotjuggler-lsl/liblsl/src/sample.h:45:44: error: ‘numeric_limits’ is not a member of ‘std’
   45 | const bool format_ieee754[] = {false, std::numeric_limits<float>::is_iec559,
      |                                            ^~~~~~~~~~~~~~
```

# Expected Outcome

Once the dependencies below are installed, following the instructions on this page works on Ubuntu 22.04:
https://github.com/PlotJuggler/plotjuggler-lsl

``` bash
sudo apt -y install qtbase5-dev libqt5svg5-dev libqt5websockets5-dev \
      libqt5opengl5-dev libqt5x11extras5-dev libprotoc-dev libzmq3-dev \
      liblz4-dev libzstd-dev
```